### PR TITLE
Non-Integer Binning 2nd Amendment

### DIFF
--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -293,7 +293,7 @@ class EDSSpectrum(Signal1D):
 
         m.get_dimensions_from_data()
         for s, step in zip(m.axes_manager._axes, scale):
-            s.scale /= step
+            s.scale *= step
         if "Acquisition_instrument.SEM.Detector.EDS.real_time" in m.metadata:
             for i, t in enumerate(m.axes_manager.navigation_axes):
                 m.metadata.Acquisition_instrument.SEM.Detector.EDS.real_time\

--- a/hyperspy/_signals/eds.py
+++ b/hyperspy/_signals/eds.py
@@ -285,8 +285,6 @@ class EDSSpectrum(Signal1D):
         """
 
         spectrum = self.data
-        newSpectrum = np.zeros(spectrum.shape)
-        newSpectrum = spectrum[:]
         newSpectrum = _linear_bin(spectrum, scale)
 
         m = self._deepcopy_with_new_data(newSpectrum)

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1297,8 +1297,6 @@ class EELSSpectrum(Signal1D):
         """
 
         spectrum = self.data
-        newSpectrum = np.zeros(spectrum.shape)
-        newSpectrum = spectrum[:]
         newSpectrum = _linear_bin(spectrum, scale)
 
         m = self._deepcopy_with_new_data(newSpectrum)

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -34,6 +34,7 @@ from hyperspy.external.progressbar import progressbar
 from hyperspy.components1d import PowerLaw
 from hyperspy.misc.utils import isiterable, closest_power_of_two, underline
 from hyperspy.misc.utils import without_nans
+from hyperspy.misc.array_tools import _linear_bin
 
 _logger = logging.getLogger(__name__)
 

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1305,5 +1305,9 @@ class EELSSpectrum(Signal1D):
         m.get_dimensions_from_data()
         for s, step in zip(m.axes_manager._axes, scale):
             s.scale /= step
+        if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata: # Correct label to be determined
+            for i, t in enumerate(m.axes_manager.navigation_axes): # May not be dwell time, but "exposure".
+                m.metadata.Acquisition_instrument.TEM.Detector.EELS.dwell_time \
+                    *= scale[i]
 
         return m

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1305,7 +1305,7 @@ class EELSSpectrum(Signal1D):
 
         m.get_dimensions_from_data()
         for s, step in zip(m.axes_manager._axes, scale):
-            s.scale /= step
+            s.scale *= step
         if "Acquisition_instrument.TEM.Detector.EELS.dwell_time" in m.metadata: # Correct label to be determined
             for i, t in enumerate(m.axes_manager.navigation_axes): # May not be dwell time, but "exposure".
                 m.metadata.Acquisition_instrument.TEM.Detector.EELS.dwell_time \

--- a/hyperspy/_signals/eels.py
+++ b/hyperspy/_signals/eels.py
@@ -1252,3 +1252,58 @@ class EELSSpectrum(Signal1D):
                           GOS=GOS,
                           dictionary=dictionary)
         return model
+
+    def linear_bin(self, scale):
+
+        """
+        Binning of the spectrum image by a non-integer pixel value.
+
+        Parameters
+        ----------
+        self: numpy.array
+            the original spectrum
+        scale: a list of floats for each dimension specify the new:old pixel
+        ratio
+        e.g. [1, 1, 2]
+            a ratio of 1 is no binning in the x and y directions.
+             a ratio of 2 means that each pixel in the new spectrum is
+             twice the width of the pixels in the old spectrum, in the energy,
+             dimension.
+
+        Return
+        ------
+        numpy.array of the spectrum with new dimensions width/step.
+
+
+        Examples
+        --------
+        Input:
+        spectrum = hs.signals.EDSTEMSpectrum(np.ones([4, 4, 10]))
+        spectrum.data[1, 2, 9] = 5
+        print(spectrum)
+        print ('Sum = ', sum(sum(sum(spectrum.data))))
+        scale = [2, 2, 5]
+        test = spectrum.linear_bin(scale)
+        print(test)
+        print('Sum = ', sum(sum(sum(test.data))))
+
+        Output:
+        <EDSTEMSpectrum, title: , dimensions: (4, 4|10)>
+        Sum =  164.0
+        <EDSTEMSpectrum, title: , dimensions: (2, 2|2)>
+        Sum =  164.0
+
+        """
+
+        spectrum = self.data
+        newSpectrum = np.zeros(spectrum.shape)
+        newSpectrum = spectrum[:]
+        newSpectrum = _linear_bin(spectrum, scale)
+
+        m = self._deepcopy_with_new_data(newSpectrum)
+
+        m.get_dimensions_from_data()
+        for s, step in zip(m.axes_manager._axes, scale):
+            s.scale /= step
+
+        return m

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2316,8 +2316,7 @@ class BaseSignal(FancySlicing,
         signal_dimension = self.axes_manager.signal_dimension
         # The following reverses the order of binning factors for the signal dimensions, as is necessary for signal2Ds
         scale = scale[0:-signal_dimension] + scale[::-1][0:signal_dimension]
-        newSpectrum = np.zeros(spectrum.shape)
-        newSpectrum = spectrum[:]
+
         newSpectrum = _linear_bin(spectrum, scale)
 
         m = self._deepcopy_with_new_data(newSpectrum)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -55,6 +55,7 @@ from hyperspy.docstrings.plot import (
 from hyperspy.events import Events, Event
 from hyperspy.interactive import interactive
 from hyperspy.misc.signal_tools import are_signals_aligned
+from hyperspy.misc.array_tools import _linear_bin
 
 import warnings
 
@@ -2269,6 +2270,60 @@ class BaseSignal(FancySlicing,
             out.events.data_changed.trigger(obj=out)
 
     rebin.__doc__ %= OUT_ARG
+
+    def linear_bin(self, scale):
+
+        """
+        Binning of the spectrum image by a non-integer pixel value.
+
+        Parameters
+        ----------
+        self: numpy.array
+            the original spectrum
+        scale: a list of floats for each dimension specify the new:old pixel
+        ratio
+        e.g. [1, 1, 2]
+            a ratio of 1 is no binning in the x and y directions.
+             a ratio of 2 means that each pixel in the new spectrum is
+             twice the width of the pixels in the old spectrum, in the energy,
+             dimension.
+
+        Return
+        ------
+        numpy.array of the spectrum with new dimensions width/step.
+
+
+        Examples
+        --------
+        Input:
+        spectrum = hs.signals.EDSTEMSpectrum(np.ones([4, 4, 10]))
+        spectrum.data[1, 2, 9] = 5
+        print(spectrum)
+        print ('Sum = ', sum(sum(sum(spectrum.data))))
+        scale = [2, 2, 5]
+        test = spectrum.linear_bin(scale)
+        print(test)
+        print('Sum = ', sum(sum(sum(test.data))))
+
+        Output:
+        <EDSTEMSpectrum, title: , dimensions: (4, 4|10)>
+        Sum =  164.0
+        <EDSTEMSpectrum, title: , dimensions: (2, 2|2)>
+        Sum =  164.0
+
+        """
+        spectrum = self.data
+        newSpectrum = np.zeros(spectrum.shape)
+        newSpectrum = spectrum[:]
+        newSpectrum = _linear_bin(spectrum, scale)
+
+        m = self._deepcopy_with_new_data(newSpectrum)
+
+        m.get_dimensions_from_data()
+        for s, step in zip(m.axes_manager._axes, scale):
+            s.scale /= step
+
+        return m
 
     def split(self,
               axis='auto',

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2324,7 +2324,7 @@ class BaseSignal(FancySlicing,
 
         m.get_dimensions_from_data()
         for s, step in zip(m.axes_manager._axes, scale):
-            s.scale *= step
+            s.scale /= step
 
         return m
 

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2313,6 +2313,9 @@ class BaseSignal(FancySlicing,
 
         """
         spectrum = self.data
+        signal_dimension = self.axes_manager.signal_dimension
+        # The following reverses the order of binning factors for the signal dimensions, as is necessary for signal2Ds
+        scale = scale[0:-signal_dimension] + scale[::-1][0:signal_dimension]
         newSpectrum = np.zeros(spectrum.shape)
         newSpectrum = spectrum[:]
         newSpectrum = _linear_bin(spectrum, scale)

--- a/hyperspy/signal.py
+++ b/hyperspy/signal.py
@@ -2324,7 +2324,7 @@ class BaseSignal(FancySlicing,
 
         m.get_dimensions_from_data()
         for s, step in zip(m.axes_manager._axes, scale):
-            s.scale /= step
+            s.scale *= step
 
         return m
 


### PR DESCRIPTION
The two mains thing here are reversing the order of the _signal_ binning_dimensions so that Signal2Ds (and for the future, Signal3Ds) work as expected and giving BaseSignal back a method - which is overwritten in the cases of EDS and EELS.  In addition are a bugfix, code tidying.

I think the BaseSignal method should be fine, but this is your PR, so you do as you wish :)
